### PR TITLE
Add issue_state to tasks for GitHub issue tracking

### DIFF
--- a/src/components/tasks/CreateTaskModal.tsx
+++ b/src/components/tasks/CreateTaskModal.tsx
@@ -105,7 +105,7 @@ export function CreateTaskModal({ onClose }: CreateTaskModalProps) {
       const result = await createTask({
         title, description, assigned_to: assignedTo, created_by: profile.id,
         deadline: new Date(deadline).toISOString(), tokens, status: 'Pending', director_approved: false,
-        pow_url: powUrl.trim() || null,
+        pow_url: powUrl.trim() || null, issue_state: null,
       }, profile.role);
       if (result.error) setError(result.error);
       else onClose();

--- a/src/components/tasks/GHIssueBadge.tsx
+++ b/src/components/tasks/GHIssueBadge.tsx
@@ -9,7 +9,7 @@ interface GHIssueShort { number: number; title: string; state: string; pull_requ
 const GH_RE = /github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/;
 
 /** Compact badge showing GH issue open/closed state. Click → full modal. Refresh button re-fetches state. */
-export function GHIssueBadge({ url, onRefresh }: { url: string; onRefresh?: () => void }) {
+export function GHIssueBadge({ url, dbState, onRefresh }: { url: string; dbState?: string | null; onRefresh?: () => void }) {
   const gh = useMemo(() => loadGHSettings(), []);
   const match = url.match(GH_RE);
   const [issue, setIssue] = useState<IssueData | null>(null);
@@ -30,12 +30,17 @@ export function GHIssueBadge({ url, onRefresh }: { url: string; onRefresh?: () =
   useEffect(() => { fetchIssue(); }, [fetchIssue]);
 
   if (!match) return null;
-  if (!active || !issue) return (
-    <a href={url} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}
-      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold border bg-gray-500/15 text-gray-400 border-gray-500/30 hover:bg-gray-500/25 transition-all">
-      <GitPullRequest className="w-3 h-3" />#{num}
-    </a>
-  );
+  if (!active || !issue) {
+    const st = dbState;
+    return (
+      <a href={url} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}
+        className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold border hover:opacity-80 transition-all ${
+          st === 'open' ? 'bg-green-500/15 text-green-500 border-green-500/30' : st === 'closed' ? 'bg-purple-500/15 text-purple-400 border-purple-500/30' : 'bg-gray-500/15 text-gray-400 border-gray-500/30'
+        }`}>
+        <GitPullRequest className="w-3 h-3" />#{num}{st ? ` ${st}` : ''}
+      </a>
+    );
+  }
 
   const isOpen = issue.state === 'open';
 
@@ -95,7 +100,7 @@ export function GHIssueBadge({ url, onRefresh }: { url: string; onRefresh?: () =
 }
 
 /** Smart issue picker: repo selector → issue list → pick. Also supports edit/unlink. */
-export function LinkIssueButton({ currentUrl, onSave, onUnlink }: { currentUrl?: string | null; onSave: (url: string) => void; onUnlink?: () => void }) {
+export function LinkIssueButton({ currentUrl, onSave, onUnlink }: { currentUrl?: string | null; onSave: (url: string, state?: string) => void; onUnlink?: () => void }) {
   const gh = useMemo(() => loadGHSettings(), []);
   const [open, setOpen] = useState(false);
   const [selectedRepo, setSelectedRepo] = useState(gh.repos.length ? `${gh.repos[0].owner}/${gh.repos[0].repo}` : '');
@@ -117,7 +122,7 @@ export function LinkIssueButton({ currentUrl, onSave, onUnlink }: { currentUrl?:
 
   const pick = (issue: GHIssueShort) => {
     const [owner, repo] = selectedRepo.split('/');
-    onSave(`https://github.com/${owner}/${repo}/issues/${issue.number}`);
+    onSave(`https://github.com/${owner}/${repo}/issues/${issue.number}`, issue.state);
     setOpen(false);
   };
 

--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -161,7 +161,7 @@ export function TaskCard({ task, showActions = true, isAdminView = false }: Task
   const canDelete = profile?.role === 'Admin' || profile?.role === 'Director';
   const canExtendDeadline = (profile?.role === 'Admin' || profile?.role === 'Director') && task.status === 'Pending';
   const canGiveFeedback = (profile?.role === 'Admin' || profile?.role === 'Director') && (task.status === 'Completed' || task.status === 'Rejected' || task.status === 'Under Review');
-  const canLinkIssue = ghActive && (profile?.role === 'Admin' || profile?.role === 'Director') && task.status === 'Completed';
+  const canLinkIssue = ghActive && (profile?.role === 'Admin' || profile?.role === 'Director');
   const isDeadlineExtended = !!task.original_deadline;
   const isForeignTask = profile && task.created_by !== profile.id;
   const foreignCreatorName = isForeignTask ? (users.find(u => u.id === task.created_by)?.full_name || 'another admin') : '';
@@ -201,7 +201,7 @@ export function TaskCard({ task, showActions = true, isAdminView = false }: Task
                 </span>
               )}
               <TaskStatusBadge status={task.status} />
-              {isGHIssue && <GHIssueBadge url={task.pow_url!} />}
+              {isGHIssue && <GHIssueBadge url={task.pow_url!} dbState={task.issue_state} />}
             </div>
           </div>
         </div>
@@ -350,7 +350,7 @@ export function TaskCard({ task, showActions = true, isAdminView = false }: Task
             {canLinkIssue && (
               <LinkIssueButton
                 currentUrl={task.pow_url}
-                onSave={async url => { await useTaskStore.getState().linkPowUrl(task.id, url); }}
+                onSave={async (url, state) => { await useTaskStore.getState().linkPowUrl(task.id, url, state); }}
                 onUnlink={task.pow_url ? async () => { await useTaskStore.getState().linkPowUrl(task.id, ''); } : undefined}
               />
             )}

--- a/src/components/tasks/TaskDetailModal.tsx
+++ b/src/components/tasks/TaskDetailModal.tsx
@@ -233,7 +233,7 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
                 className="underline truncate" style={{ color: 'var(--color-primary)' }}>
                 {task.pow_url}
               </a>
-              <GHIssueBadge url={task.pow_url} />
+              <GHIssueBadge url={task.pow_url} dbState={task.issue_state} />
             </div>
           )}
 

--- a/src/stores/taskStore.ts
+++ b/src/stores/taskStore.ts
@@ -40,7 +40,8 @@ interface TaskState {
   addFeedback: (taskId: string, feedback: string) => Promise<{ error: string | null }>;
   extendDeadline: (taskId: string, newDeadline: string, actorId: string) => Promise<{ error: string | null }>;
   deleteTask: (taskId: string, actorId: string) => Promise<{ error: string | null }>;
-  linkPowUrl: (taskId: string, url: string) => Promise<{ error: string | null }>;
+  linkPowUrl: (taskId: string, url: string, issueState?: string | null) => Promise<{ error: string | null }>;
+  refreshIssueStates: () => Promise<void>;
   subscribeToTasks: () => () => void;
   reset: () => void;
 }
@@ -73,6 +74,8 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       const { data } = await taskService.fetchTasks(userId, role);
       if (data) {
         set({ tasks: data, initialized: true, lastFetch: Date.now() });
+        // Background-refresh GH issue states for users with PAT
+        get().refreshIssueStates();
       }
     } catch (err) {
       logger.error(CAT, 'fetchTasks threw', { error: String(err) });
@@ -553,12 +556,50 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   // -----------------------------------------------------------------------
   // Link pow_url to existing task
   // -----------------------------------------------------------------------
-  linkPowUrl: async (taskId, url) => {
+  linkPowUrl: async (taskId, url, issueState) => {
     const val = url || null;
-    const { error } = await taskService.updateTask(taskId, { pow_url: val });
+    const fields: Partial<Task> = { pow_url: val, issue_state: val ? (issueState ?? null) : null };
+    const { error } = await taskService.updateTask(taskId, fields);
     if (error) return { error };
-    set(s => ({ tasks: s.tasks.map(t => t.id === taskId ? { ...t, pow_url: val } : t) }));
+    set(s => ({ tasks: s.tasks.map(t => t.id === taskId ? { ...t, ...fields } : t) }));
     return { error: null };
+  },
+
+  refreshIssueStates: async () => {
+    const { loadGHSettings } = await import('../lib/githubSettings');
+    const gh = loadGHSettings();
+    if (!gh.enabled || !gh.token) return;
+    const GH_RE = /github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/;
+    const tasks = get().tasks.filter(t => t.pow_url && GH_RE.test(t.pow_url));
+    if (!tasks.length) return;
+    const byRepo = new Map<string, { id: string; num: string; cur: string | null }[]>();
+    for (const t of tasks) {
+      const m = t.pow_url!.match(GH_RE)!;
+      const key = `${m[1]}/${m[2]}`;
+      if (!byRepo.has(key)) byRepo.set(key, []);
+      byRepo.get(key)!.push({ id: t.id, num: m[3], cur: t.issue_state });
+    }
+    const updates: { id: string; state: string }[] = [];
+    await Promise.all([...byRepo.entries()].map(async ([repo, items]) => {
+      try {
+        const res = await fetch(`https://api.github.com/repos/${repo}/issues?state=all&per_page=100&sort=updated`, {
+          headers: { Authorization: `Bearer ${gh.token}`, Accept: 'application/vnd.github+json' },
+        });
+        if (!res.ok) return;
+        const issues: { number: number; state: string }[] = await res.json();
+        const stateMap = new Map(issues.map(i => [String(i.number), i.state]));
+        for (const item of items) {
+          const s = stateMap.get(item.num);
+          if (s && s !== item.cur) updates.push({ id: item.id, state: s });
+        }
+      } catch { /* ignore */ }
+    }));
+    if (!updates.length) return;
+    await Promise.all(updates.map(u => taskService.updateTask(u.id, { issue_state: u.state })));
+    set(s => {
+      const map = new Map(updates.map(u => [u.id, u.state]));
+      return { tasks: s.tasks.map(t => map.has(t.id) ? { ...t, issue_state: map.get(t.id)! } : t) };
+    });
   },
 
   // -----------------------------------------------------------------------

--- a/src/stores/taskStore.ts
+++ b/src/stores/taskStore.ts
@@ -106,7 +106,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       set((s) => ({ tasks: [data, ...s.tasks] }));
 
       // Apply banked time: extend deadline & reset user's bank (fire-and-forget)
-      supabase.from('profiles').select('banked_minutes').eq('id', task.assigned_to).single()
+      Promise.resolve(supabase.from('profiles').select('banked_minutes').eq('id', task.assigned_to).single())
         .then(({ data: p }) => {
           if (p && p.banked_minutes > 0) {
             const extended = new Date(data.deadline);
@@ -225,7 +225,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
         // Bank remaining time if submitted early
         const remaining = Math.max(0, Math.floor((new Date(task.deadline).getTime() - Date.now()) / 60000));
         if (remaining > 0) {
-          supabase.rpc('increment_banked_minutes', { p_user_id: actorId, p_minutes: remaining }).then(() =>
+          Promise.resolve(supabase.rpc('increment_banked_minutes', { p_user_id: actorId, p_minutes: remaining })).then(() =>
             logger.info(CAT, 'banked early-finish time', { minutes: remaining, userId: actorId })
           ).catch(() => {});
         }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -40,6 +40,7 @@ export interface Task {
   submission_note: string | null;
   admin_feedback: string | null;
   pow_url: string | null;
+  issue_state: string | null;
   submitted_at: string | null;
   approved_at: string | null;
   created_at: string;

--- a/supabase/migrations/20260302153944_add_issue_state.sql
+++ b/supabase/migrations/20260302153944_add_issue_state.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.tasks ADD COLUMN IF NOT EXISTS issue_state TEXT;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -59,6 +59,9 @@ ALTER TABLE public.tasks ADD COLUMN IF NOT EXISTS original_deadline TIMESTAMPTZ;
 -- Migration: Add pow_url column for Proof of Work links
 ALTER TABLE public.tasks ADD COLUMN IF NOT EXISTS pow_url TEXT;
 
+-- Migration: Add issue_state column to cache GH issue open/closed state
+ALTER TABLE public.tasks ADD COLUMN IF NOT EXISTS issue_state TEXT;
+
 -- 3. Create points log table
 CREATE TABLE IF NOT EXISTS public.points_log (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,


### PR DESCRIPTION
This pull request adds support for tracking and displaying the open/closed state of linked GitHub issues for tasks. It introduces a new database column to cache the issue state, updates the UI to show this state, and implements logic to refresh and manage the cached values. These changes improve visibility into the status of linked issues and enable more robust integration with GitHub.

**Database and Data Model Updates**
- Added a new `issue_state` column to the `tasks` table to cache the open/closed state of linked GitHub issues. This is included in both migration and schema files, and the `Task` type is updated accordingly. [[1]](diffhunk://#diff-06fd02654859c1286ac855ebc9e58448ce873417fc2658b1add43b357d73ceb3R43) [[2]](diffhunk://#diff-c297ec8bff73be6b906beb38221420b6e5b416f2595bec642816693dbd28c334R1) [[3]](diffhunk://#diff-23135fa07bae8f6f00bbf8f64c86b841a74dc3d874772a379cace1aaefe14c26R62-R64)

**Task Store Enhancements**
- Updated the `linkPowUrl` method in `taskStore` to accept and store the GitHub issue state when linking a Proof of Work URL, and added a new `refreshIssueStates` method to batch-refresh issue states for all tasks with linked GitHub issues. The store now triggers a background refresh of issue states on task fetch for users with a GitHub token. [[1]](diffhunk://#diff-1bc25ec709da47f95657ea809ef15bb165b96709afaf3eb94cbd4a22c4411235L43-R44) [[2]](diffhunk://#diff-1bc25ec709da47f95657ea809ef15bb165b96709afaf3eb94cbd4a22c4411235R77-R78) [[3]](diffhunk://#diff-1bc25ec709da47f95657ea809ef15bb165b96709afaf3eb94cbd4a22c4411235L556-R604)

**UI Improvements for Issue State**
- Modified the `GHIssueBadge` component to accept and display the cached issue state (`dbState`) when GitHub API data is unavailable, and updated all usages to pass this prop. [[1]](diffhunk://#diff-943cce9d91ebebee9b26bcabc8f4bcfafc984e2fff01ddce9cd0539a0a8504a8L12-R12) [[2]](diffhunk://#diff-943cce9d91ebebee9b26bcabc8f4bcfafc984e2fff01ddce9cd0539a0a8504a8L33-R43) [[3]](diffhunk://#diff-ac694edf161d77947abb7bd906338a6c346062ac6fce2d81b3ea9cb8969f8586L204-R204) [[4]](diffhunk://#diff-19efd8cc2d8cac2a73cce6337660edc62d02ec342dfff5a8f57d1d64f54092e7L236-R236)
- Updated the `LinkIssueButton` to also capture the issue state when linking a GitHub issue, and propagate it through the store. [[1]](diffhunk://#diff-943cce9d91ebebee9b26bcabc8f4bcfafc984e2fff01ddce9cd0539a0a8504a8L98-R103) [[2]](diffhunk://#diff-943cce9d91ebebee9b26bcabc8f4bcfafc984e2fff01ddce9cd0539a0a8504a8L120-R125) [[3]](diffhunk://#diff-ac694edf161d77947abb7bd906338a6c346062ac6fce2d81b3ea9cb8969f8586L353-R353)

**Task Card Permission Change**
- Relaxed the condition for when admins and directors can link GitHub issues to tasks, allowing linking at any task status, not just when completed.

**Other**
- When creating a new task, the `issue_state` is now initialized as `null`.